### PR TITLE
Resolve issue 12

### DIFF
--- a/indra_network_search/frontend/src/components/header_info/HeaderInfo.vue
+++ b/indra_network_search/frontend/src/components/header_info/HeaderInfo.vue
@@ -8,10 +8,6 @@
     <template v-if="graph_date">Last updated: {{ graph_date }}.</template>
     Server Status: <span class="badge" :class="badgeClass">{{ status }}</span>
   </p>
-  <p class="text-center">
-    Read the <a href="https://network.indra.bio/api/docs">API Docs</a> and read
-    the <a href="https://indra-network-search.readthedocs.io/en/latest/">General Docs</a>
-  </p>
 </template>
 
 <script>

--- a/indra_network_search/frontend/src/components/header_info/HeaderInfo.vue
+++ b/indra_network_search/frontend/src/components/header_info/HeaderInfo.vue
@@ -6,7 +6,7 @@
       {{ unsigned_edges }} edges.<br></template
     >
     <template v-if="graph_date">Last updated: {{ graph_date }}.</template>
-    Current status: <span class="badge" :class="badgeClass">{{ status }}</span>
+    Server Status: <span class="badge" :class="badgeClass">{{ status }}</span>
   </p>
   <p class="text-center">
     Read the <a href="https://network.indra.bio/api/docs">API Docs</a> and read

--- a/indra_network_search/frontend/src/views/About.vue
+++ b/indra_network_search/frontend/src/views/About.vue
@@ -2,8 +2,26 @@
   <div class="about">
     <h1>The INDRA Network Search</h1>
     <p>
-      The INDRA Network Search is a project that centers around making a
-      knowledge graph representation of the INDRA DataBase searchable
+      The INDRA Network Search makes paths in causal graph representations of the
+      INDRA Database searchable through a user interface and REST API.
+    </p>
+    <p class="text-center">
+      You can find the REST API documentation <a href="https://network.indra.bio/api/docs">here</a>
+      (using <a href="https://github.com/swagger-api/swagger-ui">Swagger UI</a>)
+      and <a href="https://network.indra.bio/api/redoc">here</a>
+      (same information, using <a href="https://github.com/Rebilly/ReDoc">ReDoc</a>).<br>
+      You can find this project's documentation, including the codebase,
+      <a href="https://indra-network-search.readthedocs.io/en/latest/">here</a>.
+      Don't miss the Web UI
+      <a href="https://indra-network-search.readthedocs.io/en/latest/ui_introduction.html">introduction page</a>.
+    </p>
+    <p>
+      The code for this project is available on <a href="https://github.com/indralab/indra_network_search">GitHub</a>.
+    </p>
+    <p>
+      To read more about INDRA, see the <a href="https://www.indra.bio/">homepage</a>, the
+      <a href="https://indra.readthedocs.io/en/latest/">documentation</a> and the project on
+      <a href="https://github.com/sorgerlab/indra">github</a>.
     </p>
   </div>
 </template>

--- a/indra_network_search/frontend/vue.config.js
+++ b/indra_network_search/frontend/vue.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    pages: {
+        index: {
+            entry: 'src/main.js',
+            title: 'INDRA Network Search',
+        }
+    }
+}


### PR DESCRIPTION
This PR resolves #12:

- The title of the search page is set in `indra_network_search/frontend/vue.config.js`
- Expand the text on the About page and move links to repository, documentation there
- Rename `Current Status` -> `Server Status`