### PR TITLE
Various bug fixes and added tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         sudo apt-get install libstdc++6 graphviz python3-dev libgraphviz-dev pkg-config
         python -m pip install --upgrade pip
         pip install -e .[tests]
-        pip install termcolor cachetools httpx
+        pip install termcolor cachetools httpx==0.27.2
         git clone https://github.com/gyorilab/depmap_analysis.git
     - name: Run unit tests
       run: |

--- a/indra_network_search/data_models/__init__.py
+++ b/indra_network_search/data_models/__init__.py
@@ -300,7 +300,7 @@ class ShortestSimplePathOptions(BaseModel):
     source: Union[str, Tuple[str, int]]
     target: Union[str, Tuple[str, int]]
     weight: Optional[str] = None
-    ignore_nodes: Optional[Set[str]] = None
+    ignore_nodes: Optional[Set[Union[str, Tuple[str, int]]]] = None
     ignore_edges: Optional[Set[Tuple[str, str]]] = None
     hashes: Optional[List[int]] = None
     ref_counts_function: Optional[Callable] = None

--- a/indra_network_search/data_models/__init__.py
+++ b/indra_network_search/data_models/__init__.py
@@ -37,6 +37,7 @@ from pydantic import (
     conint,
     conlist,
     constr,
+    root_validator,
     validator,
 )
 
@@ -197,6 +198,19 @@ class NetworkSearchQuery(BaseModel):
         if isinstance(cbn, int) and cbn < 2:
             raise ValueError("cull_best_node must be integer > 1 if provided")
         return cbn
+
+    @root_validator
+    def mesh_ids_required_for_context(cls, values):
+        """MeSH context weighting requires at least one MeSH ID."""
+        # Todo: Also validate the mesh IDs
+        if values.get("weighted") != "context":
+            return values
+        mesh_ids = values.get("mesh_ids") or []
+        if not any(isinstance(m, str) and m.strip() for m in mesh_ids):
+            raise ValueError(
+                "mesh_ids must contain at least one MeSH ID when weighted is 'context'"
+            )
+        return values
 
     @classmethod
     def from_share_url(cls, share_url: str):

--- a/indra_network_search/frontend/src/components/Form/BaseInputBS.vue
+++ b/indra_network_search/frontend/src/components/Form/BaseInputBS.vue
@@ -6,6 +6,7 @@
       :value="modelValue"
       :placeholder="ph"
       :title="compTitle"
+      @blur="$emit('blur', $event)"
       @input="$emit('update:modelValue', $event.target.value)"
       class="form-control"
     />
@@ -25,6 +26,7 @@
 import UniqueID from "@/helpers/BasicHelpers";
 
 export default {
+  emits: ["update:modelValue", "blur"],
   props: {
     label: {
       type: String,

--- a/indra_network_search/frontend/src/views/NetworkSearchForm.vue
+++ b/indra_network_search/frontend/src/views/NetworkSearchForm.vue
@@ -568,7 +568,13 @@ export default {
         filter_curated: this.filter_curated,
         allowed_ns: this.allowed_ns, // Pick from multi-select
         node_blacklist: this.splitTrim(this.node_blacklist_text),
-        path_length: this.path_length,
+        path_length:
+          this.path_length === "" ||
+          this.path_length == null ||
+          (typeof this.path_length === "number" && Number.isNaN(this.path_length)) ||
+          this.path_length === 0
+            ? null
+            : this.path_length,
         depth_limit: this.depth_limit,
         sign: this.sign === "" ? null : this.sign,
         weighted: this.weighted,

--- a/indra_network_search/frontend/src/views/NetworkSearchForm.vue
+++ b/indra_network_search/frontend/src/views/NetworkSearchForm.vue
@@ -229,6 +229,8 @@
                     label="Mesh IDs (comma separated)"
                     type="text"
                     :allowWhitespace="false"
+                    :errors="meshIdsFieldErrors"
+                    @blur="touchMeshIds"
                   />
                 </div>
                 <div class="col-4">
@@ -455,6 +457,7 @@ export default {
       max_per_node: DefaultValues.MAX_PER_NODE,
       cull_best_node: null,
       mesh_ids_text: "",
+      meshIdsTouched: false,
       strict_mesh_id_filtering: false,
       const_c: DefaultValues.CONST_C,
       const_tk: DefaultValues.CONST_TK,
@@ -613,6 +616,25 @@ export default {
     isNotOpenSearch() {
       return this.source.length > 0 && this.target.length > 0;
     },
+    meshContextMissingMeshIds() {
+      if (this.weighted !== "context") {
+        return false;
+      }
+      const ids = this.splitTrim(this.mesh_ids_text).filter((id) => id.length > 0);
+      return ids.length === 0;
+    },
+    meshIdsFieldErrors() {
+      if (!this.meshContextMissingMeshIds || !this.meshIdsTouched) {
+        return [];
+      }
+      return [
+        {
+          $uid: "mesh-context-requires-ids",
+          $message:
+            "At least one MeSH ID is required.",
+        },
+      ];
+    },
     cannotSubmit() {
       /**
        * Flag if source/target are valid
@@ -628,7 +650,14 @@ export default {
       // OR target is not valid when filled
       const trgtInvalid = this.target.length > 0 && !this.validTarget
 
-      return bothEmpty || srcWhiteSpace || trgtWhiteSpace || srcInvalid || trgtInvalid
+      return (
+        bothEmpty ||
+        srcWhiteSpace ||
+        trgtWhiteSpace ||
+        srcInvalid ||
+        trgtInvalid ||
+        this.meshContextMissingMeshIds
+      );
     },
     isContextWeighted() {
       return this.isContextSearch && !this.strict_mesh_id_filtering;
@@ -672,7 +701,9 @@ export default {
     contextErrors() {
       const c = this.v$.const_c.$errors.length;
       const tk = this.v$.const_tk.$errors.length;
-      return [c, tk].reduce((ps, a) => ps + a, 0);
+      const mesh =
+        this.meshContextMissingMeshIds && this.meshIdsTouched ? 1 : 0;
+      return [c, tk, mesh].reduce((ps, a) => ps + a, 0);
     },
     openErrors() {
       const mpn = this.v$.max_per_node.$errors.length;
@@ -697,6 +728,9 @@ export default {
     },
   },
   methods: {
+    touchMeshIds() {
+      this.meshIdsTouched = true;
+    },
     async sendForm() {
       const canSubmit = await this.v$.$validate();
       if (!canSubmit || this.cannotSubmit) {
@@ -880,6 +914,11 @@ export default {
     return false;
   },
   watch: {
+    weighted(newVal) {
+      if (newVal !== "context") {
+        this.meshIdsTouched = false;
+      }
+    },
     // Watch cannotSubmit and submit form if cannotSubmit === false
     cannotSubmit(newValue) {
       if (this.querySearchExec && newValue === false) {

--- a/indra_network_search/query.py
+++ b/indra_network_search/query.py
@@ -84,6 +84,8 @@ class Query:
         self.query_hash: str = query.get_hash()
 
     def _get_node_blacklist(self) -> List[Union[str, Tuple[str, int]]]:
+        # If no node blacklist is provided, or the sign is None, return the node blacklist
+        # Otherwise, return the node blacklist with both positive and negative signs
         if not self.query.node_blacklist or self.query.sign is None:
             return self.query.node_blacklist
         else:

--- a/indra_network_search/tests/test_basemodels.py
+++ b/indra_network_search/tests/test_basemodels.py
@@ -1,4 +1,5 @@
-from indra_network_search.data_models import StmtData
+from pydantic import ValidationError
+from indra_network_search.data_models import StmtData, NetworkSearchQuery
 
 
 def test_stmt_data():
@@ -15,3 +16,40 @@ def test_stmt_data():
     }
     stmt_data = StmtData(db_url_hash=stmt_dict["stmt_hash"], **stmt_dict)
     assert stmt_data.source_counts == {"fplx": 1}
+
+
+def test_network_search_query_mesh():
+    # Test the mesh option validation
+    nsq = NetworkSearchQuery(source="A", weighted="context", mesh_ids=["D000001", "D000002"])
+    try:
+        NetworkSearchQuery(source="A", weighted="context")
+    except Exception as e:
+        assert "mesh_ids must contain at least one MeSH ID" in str(e)
+        assert isinstance(e, ValidationError)
+
+
+def test_network_search_query_cull_best_node():
+    nsq = NetworkSearchQuery(source="A", cull_best_node=2)
+    try:
+        NetworkSearchQuery(source="A", cull_best_node=1)
+    except Exception as e:
+        assert "cull_best_node must be integer > 1" in str(e)
+        assert isinstance(e, ValidationError)
+
+
+def test_network_search_query_max_per_node():
+    nsq = NetworkSearchQuery(source="A", max_per_node=2)
+    try:
+        NetworkSearchQuery(source="A", max_per_node=0)
+    except Exception as e:
+        assert "max_per_node must be integer > 0" in str(e)
+        assert isinstance(e, ValidationError)
+
+
+def test_network_search_query_path_length():
+    nsq = NetworkSearchQuery(source="A", path_length=2)
+    try:
+        NetworkSearchQuery(source="A", path_length=0)
+    except Exception as e:
+        assert "path_length must be integer > 0" in str(e)
+        assert isinstance(e, ValidationError)

--- a/indra_network_search/tests/test_query_pipeline.py
+++ b/indra_network_search/tests/test_query_pipeline.py
@@ -417,6 +417,20 @@ def test_ssp_signed_belief_weighted():
     # Todo: test result
 
 
+def test_ssp_signed_node_blacklist():
+    from indra_network_search.search_api import IndraNetworkSearchAPI
+    nsq = NetworkSearchQuery(
+        filter_curated=False,
+        source="BRCA1",
+        target="BRCA2",
+        node_blacklist=["testosterone"],
+        sign=0,
+    )
+    network_search_api = IndraNetworkSearchAPI(unsigned_graph=unsigned_graph, signed_node_graph=signed_node_graph)
+    results = network_search_api.handle_query(rest_query=nsq)
+    # Todo: test result
+
+
 def test_ssp_z_score_weighted():
     # Create rest query - belief weighted
     brca1 = Node(name="BRCA1", namespace="HGNC", identifier="1100")

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     indra_db @ git+https://github.com/indralab/indra_db.git
     fastapi<0.100.0
     pydantic!=1.8,!=1.8.1,<2.0.0,>=1.7.4
-;    Version 0.28.0 breaks the starlette verion used in fastapi<0.100.0
+;    Version 0.28.0 breaks the starlette version used in fastapi<0.100.0
     httpx==0.27.2
     networkx
     boto3


### PR DESCRIPTION
This PR fixes some minor corner case bugs present in both the frontend app and the backend, specifically:
- `ignore_nodes` in `ShortestSimplePathOptions` previosly did not allow signed nodes, leading to an error if a signed path search was done together with at least one node in the node blacklist.
- If `path_length` had a value set and then deleted, the submitted value for the `path_length`, now no longer the default null value, would cause an error.
- The Vue app would previously allow a MeSH context weighted query to be submitted without the MeSH ID text box having a value. This is fixed in the Vue app and the backend also checks for this case, raising an error if present.

A couple of tests are added and the test setup now pins httpx to ensure compatibility with the specified FastAPI version.