### PR TITLE
Expand autocomplete

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         sudo apt-get install libstdc++6 graphviz python3-dev libgraphviz-dev pkg-config
         python -m pip install --upgrade pip
         pip install -e .[tests]
-        pip install termcolor cachetools httpx
+        pip install termcolor cachetools httpx==0.27.2
         git clone https://github.com/gyorilab/depmap_analysis.git
     - name: Run unit tests
       run: |

--- a/indra_network_search/autocomplete/__init__.py
+++ b/indra_network_search/autocomplete/__init__.py
@@ -1,1 +1,1 @@
-from .autocomplete import NodesTrie, Prefixes
+from .autocomplete import NodesTrie, Prefixes, MeshPrefixes

--- a/indra_network_search/autocomplete/autocomplete.py
+++ b/indra_network_search/autocomplete/autocomplete.py
@@ -10,10 +10,11 @@ from pytrie import SortedStringTrie
 from tqdm import tqdm
 
 # Derived types
-Prefixes = List[Tuple[str, str, str]]
+Prefixes = List[Tuple[str, str, str]]  # name, ns, id
+MeshPrefixes = List[Tuple[str, str]]  # name, id
 DirGraph = Union[DiGraph, MultiDiGraph]
 
-__all__ = ["NodesTrie", "Prefixes"]
+__all__ = ["NodesTrie", "Prefixes", "MeshPrefixes"]
 
 
 class NodesTrie(SortedStringTrie):
@@ -89,6 +90,40 @@ class NodesTrie(SortedStringTrie):
             }
         )
 
+    @classmethod
+    def from_curie_name_dict(cls, curie_name_dict: dict) -> "NodesTrie":
+        """Produce a NodesTrie instance from a dict mapping curies to names
+
+        Parameters
+        ----------
+        curie_name_dict:
+            A dict mapping curies to names
+
+        Returns
+        -------
+        :
+            An instance of a NodesTrie containing the names of each node of the
+            graph as keys and the corresponding (name, id) tuple as values.
+        """
+        name_indexing = {}
+
+        for curie, name in tqdm(
+            curie_name_dict.items(),
+            desc="Building autocomplete index from curie name dict"
+        ):
+            mesh_name_lower = name.lower()
+            db_ns, db_id = curie.split(":", 1)
+            if mesh_name_lower in name_indexing:
+                ix = 1
+                mesh_name_lower += f"_{ix}"
+                # Increase index until key is not present
+                while mesh_name_lower in name_indexing:
+                    ix += 1
+                    mesh_name_lower = name.lower() + f"_{ix}"
+            name_indexing[mesh_name_lower] = (name, db_ns, db_id, 0)
+        return cls(**name_indexing)
+
+
     def case_keys(self, prefix: Optional[str] = None, top_n: Optional[int] = 100) -> List[str]:
         """Case insensitive wrapper around NodeTrie.keys()
 
@@ -124,6 +159,26 @@ class NodesTrie(SortedStringTrie):
         return [
             (name, namespace, identifier)
             for name, namespace, identifier, _ in islice(sorted(res, key=lambda t: (t[3], t[0]), reverse=True), top_n)
+        ]
+
+    def case_items_alpha(self, prefix: Optional[str] = None, top_n: int = 100) -> Prefixes:
+        """Case insensitive wrapper around NodeTrie.items() sorted alphabetically
+
+        Parameters
+        ----------
+        prefix :
+            The prefix to search
+
+        Returns
+        -------
+        :
+            Return a list of (name, namespace, id) tuples sorted alphabetically
+            by name.
+        """
+        res = (tup for _, tup in self.items(prefix.lower()))
+        return [
+            (name, namespace, identifier)
+            for name, namespace, identifier, _ in islice(sorted(res, key=lambda t: t[0]), top_n)
         ]
 
 

--- a/indra_network_search/autocomplete/autocomplete.py
+++ b/indra_network_search/autocomplete/autocomplete.py
@@ -46,7 +46,7 @@ class NodesTrie(SortedStringTrie):
             if node_name in name_indexing:
                 ix = 1
                 node_name += f"_{ix}"
-                # Increase index until no key is not present
+                # Increase index until key is not present
                 while node_name in name_indexing:
                     ix += 1
                     node_name = node.lower() + f"_{ix}"

--- a/indra_network_search/data_models/__init__.py
+++ b/indra_network_search/data_models/__init__.py
@@ -300,7 +300,7 @@ class ShortestSimplePathOptions(BaseModel):
     source: Union[str, Tuple[str, int]]
     target: Union[str, Tuple[str, int]]
     weight: Optional[str] = None
-    ignore_nodes: Optional[Set[str]] = None
+    ignore_nodes: Optional[Set[Union[str, Tuple[str, int]]]] = None
     ignore_edges: Optional[Set[Tuple[str, str]]] = None
     hashes: Optional[List[int]] = None
     ref_counts_function: Optional[Callable] = None

--- a/indra_network_search/data_models/__init__.py
+++ b/indra_network_search/data_models/__init__.py
@@ -37,6 +37,7 @@ from pydantic import (
     conint,
     conlist,
     constr,
+    root_validator,
     validator,
 )
 
@@ -197,6 +198,19 @@ class NetworkSearchQuery(BaseModel):
         if isinstance(cbn, int) and cbn < 2:
             raise ValueError("cull_best_node must be integer > 1 if provided")
         return cbn
+
+    @root_validator
+    def mesh_ids_required_for_context(cls, values):
+        """MeSH context weighting requires at least one MeSH ID."""
+        # Todo: Also validate the mesh IDs
+        if values.get("weighted") != "context":
+            return values
+        mesh_ids = values.get("mesh_ids") or []
+        if not any(isinstance(m, str) and m.strip() for m in mesh_ids):
+            raise ValueError(
+                "mesh_ids must contain at least one MeSH ID when weighted is 'context'"
+            )
+        return values
 
     @classmethod
     def from_share_url(cls, share_url: str):

--- a/indra_network_search/frontend/src/components/Form/BaseInputBS.vue
+++ b/indra_network_search/frontend/src/components/Form/BaseInputBS.vue
@@ -6,6 +6,7 @@
       :value="modelValue"
       :placeholder="ph"
       :title="compTitle"
+      @blur="$emit('blur', $event)"
       @input="$emit('update:modelValue', $event.target.value)"
       class="form-control"
     />
@@ -25,6 +26,7 @@
 import UniqueID from "@/helpers/BasicHelpers";
 
 export default {
+  emits: ["update:modelValue", "blur"],
   props: {
     label: {
       type: String,

--- a/indra_network_search/frontend/src/components/Form/MeshIdsAsyncMultiselect.vue
+++ b/indra_network_search/frontend/src/components/Form/MeshIdsAsyncMultiselect.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="mesh-ids-async-ms" @focusout="onFocusOut">
+    <label v-if="label" class="form-label small text-muted mb-1 d-block">{{
+      label
+    }}</label>
+    <Multiselect
+      :model-value="modelValue"
+      mode="tags"
+      :placeholder="placeholder"
+      :title="title || placeholder"
+      :disabled="disabled"
+      :searchable="true"
+      :create-tag="false"
+      :options="meshOptions"
+      :filter-results="false"
+      :delay="250"
+      :min-chars="1"
+      :resolve-on-load="false"
+      value-prop="value"
+      label="label"
+      @update:model-value="$emit('update:modelValue', $event)"
+    />
+    <template v-if="errors.length > 0">
+      <p v-for="error in errors" :key="error.$uid" style="color: #a00000">
+        {{ error.$message ? error.$message : "Invalid entry" }}
+      </p>
+    </template>
+  </div>
+</template>
+
+<script>
+import Multiselect from "@vueform/multiselect";
+import AxiosMethods from "@/services/AxiosMethods";
+
+export default {
+  name: "MeshIdsAsyncMultiselect",
+  components: { Multiselect },
+  props: {
+    modelValue: {
+      type: Array,
+      default: () => [],
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    errors: {
+      type: Array,
+      default: () => [],
+    },
+    label: {
+      type: String,
+      default: "Mesh IDs",
+    },
+    placeholder: {
+      type: String,
+      default: "Search MeSH by name, then select",
+    },
+    title: {
+      type: String,
+      default: "",
+    },
+  },
+  emits: ["update:modelValue", "blur"],
+  methods: {
+    async meshOptions(query) {
+      const q = (query || "").trim();
+      if (!q) {
+        return [];
+      }
+      try {
+        const res = await AxiosMethods.autocompleteMesh(q);
+        const rows = res.data || [];
+        return rows.map(([name, identifier]) => ({
+          value: identifier,
+          label: `${name} (${identifier})`,
+        }));
+      } catch (e) {
+        console.log("autocompleteMesh failed", e);
+        return [];
+      }
+    },
+    onFocusOut(event) {
+      const root = event.currentTarget;
+      if (root && !root.contains(event.relatedTarget)) {
+        this.$emit("blur", event);
+      }
+    },
+  },
+};
+</script>

--- a/indra_network_search/frontend/src/components/Form/NodeBlacklistAsyncMultiselect.vue
+++ b/indra_network_search/frontend/src/components/Form/NodeBlacklistAsyncMultiselect.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="node-blacklist-async-ms" @focusout="onFocusOut">
+    <Multiselect
+      :model-value="modelValue"
+      mode="tags"
+      :placeholder="placeholder"
+      :title="title"
+      :disabled="disabled"
+      :searchable="true"
+      :create-tag="false"
+      :options="nodeBlacklistOptions"
+      :filter-results="false"
+      :delay="250"
+      :min-chars="1"
+      :resolve-on-load="false"
+      value-prop="value"
+      label="label"
+      @update:model-value="$emit('update:modelValue', $event)"
+    />
+    <template v-if="errors.length > 0">
+      <p v-for="error in errors" :key="error.$uid" style="color: #a00000">
+        {{ error.$message ? error.$message : "Invalid entry" }}
+      </p>
+    </template>
+  </div>
+</template>
+
+<script>
+import Multiselect from "@vueform/multiselect";
+import AxiosMethods from "@/services/AxiosMethods";
+
+export default {
+  name: "NodeBlacklistAsyncMultiselect",
+  components: { Multiselect },
+  props: {
+    modelValue: {
+      type: Array,
+      default: () => [],
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    errors: {
+      type: Array,
+      default: () => [],
+    },
+    placeholder: {
+      type: String,
+      default: "Node blacklist",
+    },
+    title: {
+      type: String,
+      default:
+        "Start typing to search nodes from the graph to add to the blacklist",
+    },
+  },
+  emits: ["update:modelValue", "blur"],
+  methods: {
+    async nodeBlacklistOptions(query) {
+      const q = (query || "").trim();
+      if (!q) {
+        return [];
+      }
+      try {
+        const res = await AxiosMethods.auto(q);
+        const rows = res.data || [];
+        return rows.map(([name, namespace, identifier]) => ({
+          value: name,
+          label: `${name} — ${namespace}:${identifier}`,
+        }));
+      } catch (e) {
+        console.log("autocomplete (node blacklist) failed", e);
+        return [];
+      }
+    },
+    onFocusOut(event) {
+      const root = event.currentTarget;
+      if (root && !root.contains(event.relatedTarget)) {
+        this.$emit("blur", event);
+      }
+    },
+  },
+};
+</script>

--- a/indra_network_search/frontend/src/components/app_footer/AppFooter.vue
+++ b/indra_network_search/frontend/src/components/app_footer/AppFooter.vue
@@ -7,10 +7,8 @@
           <li class="float-end">
             <a href="#">Back to top</a>
           </li>
-          <li><a href="https://indralab.github.io" target="_blank">INDRALAB</a></li>
-          <li><a href="http://hits.harvard.edu" target="_blank">Harvard Program in Therapeutic Science (HiTS)</a></li>
-          <li><b>Automated Scientific Discovery Framework </b>(ASDF)</li>
-          <li>The DARPA ASDF project develops algorithms and software for reasoning about complex mechanisms operating in the natural world, explaining large-scale data, assisting humans in generating actionable, model-based hypotheses and testing these hypotheses empirically.<br><i>ASDF is funded by the Defense Advanced Research Projects Agency under award W911NF018-1-0124.</i></li>
+          <li>This software is developed by the <a href="https://gyorilab.github.io/" target="_blank">Gyori Lab for Computational Biomedicine</a> at Northeastern University</li>
+          <li>This work was funded by DARPA grant W911NF018-1-0124 under the DARPA ASDF program.</li>
         </ul>
       </small>
     </footer>

--- a/indra_network_search/frontend/src/services/AxiosMethods.js
+++ b/indra_network_search/frontend/src/services/AxiosMethods.js
@@ -26,6 +26,11 @@ export default {
   auto(prefix) {
     return apiGetClient.get(`/autocomplete?prefix=${prefix}`);
   },
+  autocompleteMesh(prefix) {
+    return apiGetClient.get("/autocomplete-mesh-name", {
+      params: { prefix },
+    });
+  },
   checkNode(name) {
     return apiGetClient.get(`/node-name-in-graph?node-name=${name}`);
   },

--- a/indra_network_search/frontend/src/views/NetworkSearchForm.vue
+++ b/indra_network_search/frontend/src/views/NetworkSearchForm.vue
@@ -223,12 +223,12 @@
                   />
                 </div>
                 <div class="col-4">
-                  <BaseInputBS
-                    v-model="mesh_ids_text"
+                  <MeshIdsAsyncMultiselect
+                    v-model="mesh_ids"
                     :disabled="weighted !== 'context'"
-                    label="Mesh IDs (comma separated)"
-                    type="text"
-                    :allowWhitespace="false"
+                    label="Mesh IDs"
+                    placeholder="Search MeSH by name, then select"
+                    title="Search MeSH by name; add multiple IDs as tags"
                     :errors="meshIdsFieldErrors"
                     @blur="touchMeshIds"
                   />
@@ -407,6 +407,7 @@
 import BaseSelectBS from "@/components/Form/BaseSelectBS";
 import BaseCheckboxBS from "@/components/Form/BaseCheckboxBS";
 import BaseInputBS from "@/components/Form/BaseInputBS";
+import MeshIdsAsyncMultiselect from "@/components/Form/MeshIdsAsyncMultiselect";
 import BaseInputAutoCompBS from "@/components/Form/BaseInputAutoCompBS";
 import ShareUrl from "@/components/Form/share-url/ShareUrl";
 import AxiosMethods from "@/services/AxiosMethods";
@@ -430,6 +431,7 @@ export default {
     BaseSelectBS,
     BaseCheckboxBS,
     BaseInputBS,
+    MeshIdsAsyncMultiselect,
     Multiselect,
     ShareUrl,
   },
@@ -456,7 +458,7 @@ export default {
       k_shortest: DefaultValues.K_SHORTEST,
       max_per_node: DefaultValues.MAX_PER_NODE,
       cull_best_node: null,
-      mesh_ids_text: "",
+      mesh_ids: [],
       meshIdsTouched: false,
       strict_mesh_id_filtering: false,
       const_c: DefaultValues.CONST_C,
@@ -587,7 +589,7 @@ export default {
         k_shortest: this.k_shortest,
         max_per_node: this.max_per_node,
         cull_best_node: this.cull_best_node,
-        mesh_ids: this.splitTrim(this.mesh_ids_text),
+        mesh_ids: [...this.mesh_ids],
         strict_mesh_id_filtering: this.strict_mesh_id_filtering,
         const_c: this.const_c,
         const_tk: this.const_tk,
@@ -611,7 +613,7 @@ export default {
       return this.nodeNamespaceOptions.map((obj) => obj.value)
     },
     isContextSearch() {
-      return this.mesh_ids_text.length > 0;
+      return this.mesh_ids.length > 0;
     },
     isNotOpenSearch() {
       return this.source.length > 0 && this.target.length > 0;
@@ -620,7 +622,9 @@ export default {
       if (this.weighted !== "context") {
         return false;
       }
-      const ids = this.splitTrim(this.mesh_ids_text).filter((id) => id.length > 0);
+      const ids = this.mesh_ids.filter(
+        (id) => typeof id === "string" && id.trim().length > 0
+      );
       return ids.length === 0;
     },
     meshIdsFieldErrors() {
@@ -829,7 +833,7 @@ export default {
         k_shortest: "input",
         max_per_node: "input",
         cull_best_node: "input",
-        mesh_ids: "input_join", // Join array to comma separated text
+        mesh_ids: "mesh_ids",
         strict_mesh_id_filtering: "checkbox",
         const_c: "input",
         const_tk: "input",
@@ -859,13 +863,22 @@ export default {
             }
           } else if (fillType === 'select' && this.isInOptions(key, value)) {
             this.$data[key] = value
+          } else if (fillType === "mesh_ids") {
+            const raw = value;
+            const arr = Array.isArray(raw)
+              ? raw
+              : String(raw)
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean);
+            this.mesh_ids = arr;
           } else if (fillType === 'input_join') {
             const formKey = key + '_text'
             let fillVal
             if (value.constructor.name === 'Array') {
               fillVal = value.join(', ')
             } else {
-              fillVal = [value]
+              fillVal = String(value)
             }
             // Transform array to comma separated string
             this.$data[formKey] = fillVal

--- a/indra_network_search/frontend/src/views/NetworkSearchForm.vue
+++ b/indra_network_search/frontend/src/views/NetworkSearchForm.vue
@@ -568,7 +568,13 @@ export default {
         filter_curated: this.filter_curated,
         allowed_ns: this.allowed_ns, // Pick from multi-select
         node_blacklist: this.splitTrim(this.node_blacklist_text),
-        path_length: this.path_length,
+        path_length:
+          this.path_length === "" ||
+          this.path_length == null ||
+          (typeof this.path_length === "number" && Number.isNaN(this.path_length)) ||
+          this.path_length === 0
+            ? null
+            : this.path_length,
         depth_limit: this.depth_limit,
         sign: this.sign === "" ? null : this.sign,
         weighted: this.weighted,

--- a/indra_network_search/frontend/src/views/NetworkSearchForm.vue
+++ b/indra_network_search/frontend/src/views/NetworkSearchForm.vue
@@ -229,6 +229,8 @@
                     label="Mesh IDs (comma separated)"
                     type="text"
                     :allowWhitespace="false"
+                    :errors="meshIdsFieldErrors"
+                    @blur="touchMeshIds"
                   />
                 </div>
                 <div class="col-4">
@@ -455,6 +457,7 @@ export default {
       max_per_node: DefaultValues.MAX_PER_NODE,
       cull_best_node: null,
       mesh_ids_text: "",
+      meshIdsTouched: false,
       strict_mesh_id_filtering: false,
       const_c: DefaultValues.CONST_C,
       const_tk: DefaultValues.CONST_TK,
@@ -613,6 +616,25 @@ export default {
     isNotOpenSearch() {
       return this.source.length > 0 && this.target.length > 0;
     },
+    meshContextMissingMeshIds() {
+      if (this.weighted !== "context") {
+        return false;
+      }
+      const ids = this.splitTrim(this.mesh_ids_text).filter((id) => id.length > 0);
+      return ids.length === 0;
+    },
+    meshIdsFieldErrors() {
+      if (!this.meshContextMissingMeshIds || !this.meshIdsTouched) {
+        return [];
+      }
+      return [
+        {
+          $uid: "mesh-context-requires-ids",
+          $message:
+            "At least one MeSH ID is required.",
+        },
+      ];
+    },
     cannotSubmit() {
       /**
        * Flag if source/target are valid
@@ -628,7 +650,14 @@ export default {
       // OR target is not valid when filled
       const trgtInvalid = this.target.length > 0 && !this.validTarget
 
-      return bothEmpty || srcWhiteSpace || trgtWhiteSpace || srcInvalid || trgtInvalid
+      return (
+        bothEmpty ||
+        srcWhiteSpace ||
+        trgtWhiteSpace ||
+        srcInvalid ||
+        trgtInvalid ||
+        this.meshContextMissingMeshIds
+      );
     },
     isContextWeighted() {
       return this.isContextSearch && !this.strict_mesh_id_filtering;
@@ -672,7 +701,9 @@ export default {
     contextErrors() {
       const c = this.v$.const_c.$errors.length;
       const tk = this.v$.const_tk.$errors.length;
-      return [c, tk].reduce((ps, a) => ps + a, 0);
+      const mesh =
+        this.meshContextMissingMeshIds && this.meshIdsTouched ? 1 : 0;
+      return [c, tk, mesh].reduce((ps, a) => ps + a, 0);
     },
     openErrors() {
       const mpn = this.v$.max_per_node.$errors.length;
@@ -697,6 +728,9 @@ export default {
     },
   },
   methods: {
+    touchMeshIds() {
+      this.meshIdsTouched = true;
+    },
     async sendForm() {
       const canSubmit = await this.v$.$validate();
       if (!canSubmit || this.cannotSubmit) {
@@ -880,6 +914,11 @@ export default {
     return false;
   },
   watch: {
+    weighted(newVal) {
+      if (newVal !== "context") {
+        this.meshIdsTouched = false;
+      }
+    },
     // Watch cannotSubmit and submit form if cannotSubmit === false
     cannotSubmit(newValue) {
       if (this.querySearchExec && newValue === false) {

--- a/indra_network_search/frontend/src/views/NetworkSearchForm.vue
+++ b/indra_network_search/frontend/src/views/NetworkSearchForm.vue
@@ -84,11 +84,10 @@
                     />
                   </div>
                   <div class="col">
-                    <BaseInputBS
-                      v-model="node_blacklist_text"
-                      label="Node Blacklist"
-                      type="text"
-                      :allowWhitespace="false"
+                    <BaseSelectBS
+                      v-model.number="sign"
+                      :options="signOptions"
+                      label="Signed Search"
                     />
                   </div>
                 </div>
@@ -105,10 +104,15 @@
                     />
                   </div>
                   <div class="col">
-                    <BaseSelectBS
-                      v-model.number="sign"
-                      :options="signOptions"
-                      label="Signed Search"
+                    <BaseInputBS
+                      v-model.number="belief_cutoff"
+                      :max="1.0"
+                      :min="0.0"
+                      :step="0.01"
+                      label="Belief Cutoff"
+                      type="number"
+                      :errors="v$.belief_cutoff.$errors"
+                      @blur="v$.belief_cutoff.$touch()"
                     />
                   </div>
                 </div>
@@ -125,15 +129,8 @@
                     />
                   </div>
                   <div class="col">
-                    <BaseInputBS
-                      v-model.number="belief_cutoff"
-                      :max="1.0"
-                      :min="0.0"
-                      :step="0.01"
-                      label="Belief Cutoff"
-                      type="number"
-                      :errors="v$.belief_cutoff.$errors"
-                      @blur="v$.belief_cutoff.$touch()"
+                    <NodeBlacklistAsyncMultiselect
+                      v-model="node_blacklist_selected"
                     />
                   </div>
                 </div>
@@ -408,6 +405,7 @@ import BaseSelectBS from "@/components/Form/BaseSelectBS";
 import BaseCheckboxBS from "@/components/Form/BaseCheckboxBS";
 import BaseInputBS from "@/components/Form/BaseInputBS";
 import MeshIdsAsyncMultiselect from "@/components/Form/MeshIdsAsyncMultiselect";
+import NodeBlacklistAsyncMultiselect from "@/components/Form/NodeBlacklistAsyncMultiselect";
 import BaseInputAutoCompBS from "@/components/Form/BaseInputAutoCompBS";
 import ShareUrl from "@/components/Form/share-url/ShareUrl";
 import AxiosMethods from "@/services/AxiosMethods";
@@ -432,6 +430,7 @@ export default {
     BaseCheckboxBS,
     BaseInputBS,
     MeshIdsAsyncMultiselect,
+    NodeBlacklistAsyncMultiselect,
     Multiselect,
     ShareUrl,
   },
@@ -446,7 +445,7 @@ export default {
       stmt_filter: [],
       filter_curated: true,
       allowed_ns: [],
-      node_blacklist_text: "",
+      node_blacklist_selected: [],
       path_length: null,
       depth_limit: DefaultValues.DEPTH_LIMIT,
       sign: null,
@@ -572,7 +571,7 @@ export default {
         stmt_filter: this.fplx_edges ? [...this.stmt_filter, 'fplx'] : this.stmt_filter, // Multiselect; add fplx edges
         filter_curated: this.filter_curated,
         allowed_ns: this.allowed_ns, // Pick from multi-select
-        node_blacklist: this.splitTrim(this.node_blacklist_text),
+        node_blacklist: [...this.node_blacklist_selected],
         path_length:
           this.path_length === "" ||
           this.path_length == null ||
@@ -822,7 +821,7 @@ export default {
         target: "input",
         stmt_filter: "multiselect",
         allowed_ns: "multiselect",
-        node_blacklist: "input_join", // Join array to comma separated text
+        node_blacklist: "node_blacklist_selected",
         path_length: "input",
         depth_limit: "input",
         sign: "select",
@@ -872,6 +871,15 @@ export default {
                   .map((s) => s.trim())
                   .filter(Boolean);
             this.mesh_ids = arr;
+          } else if (fillType === "node_blacklist_selected") {
+            const raw = value;
+            const arr = Array.isArray(raw)
+              ? raw
+              : String(raw)
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean);
+            this.node_blacklist_selected = arr;
           } else if (fillType === 'input_join') {
             const formKey = key + '_text'
             let fillVal

--- a/indra_network_search/query.py
+++ b/indra_network_search/query.py
@@ -84,6 +84,8 @@ class Query:
         self.query_hash: str = query.get_hash()
 
     def _get_node_blacklist(self) -> List[Union[str, Tuple[str, int]]]:
+        # If no node blacklist is provided, or the sign is None, return the node blacklist
+        # Otherwise, return the node blacklist with both positive and negative signs
         if not self.query.node_blacklist or self.query.sign is None:
             return self.query.node_blacklist
         else:

--- a/indra_network_search/rest_api.py
+++ b/indra_network_search/rest_api.py
@@ -65,7 +65,7 @@ network_search_api: IndraNetworkSearchAPI
 nsid_trie: NodesTrie
 nodes_trie: NodesTrie
 mesh_annotations_trie: NodesTrie
-reverse_mesh_map: dict[str, str]  # Maps name -> mesh curie
+mesh_annotations_dict: dict[str, str]  # Maps mesh curie -> name
 
 
 @app.get("/xrefs", response_model=List[List[str]])
@@ -139,16 +139,21 @@ def node_id_in_graph(
 def mesh_annotation_name_exists(
     mesh_name: str = RestQuery(..., min_length=1, alias="mesh-name"),
 ):
-    mesh_id = mesh_annotations_trie.get(mesh_name)
-    if mesh_id:
-        return mesh_name, mesh_id
+    mesh_entry = mesh_annotations_trie.get(mesh_name)
+    if mesh_entry is not None:
+        name, _, mesh_id, _ = mesh_entry
+        return name, mesh_id
 
 
 @app.get("/mesh-id-annotation-exists", response_model=Optional[Tuple[str, str]])
 def mesh_id_annotation_exists(
     mesh_id: str = RestQuery(..., min_length=1, alias="mesh-id"),
 ):
-    mesh_name = reverse_mesh_map.get(f"MESH:{mesh_id}")
+    if mesh_id.upper().startswith("MESH:"):
+        mesh_curie = mesh_id.upper()
+    else:
+        mesh_curie = f"MESH:{mesh_id.upper()}"
+    mesh_name = mesh_annotations_dict.get(mesh_curie)
     if mesh_name:
         return mesh_name, mesh_id
 
@@ -339,7 +344,7 @@ def sub_graph(search_query: SubgraphRestQuery):
 
 @app.on_event("startup")
 def startup_event():
-    global network_search_api, nsid_trie, nodes_trie, mesh_annotations_trie, reverse_mesh_map
+    global network_search_api, nsid_trie, nodes_trie, mesh_annotations_trie, mesh_annotations_dict
     # Todo: figure out how to do all the loading async so the server is
     #  available to respond to health checks while it's loading
     #  See:
@@ -350,7 +355,7 @@ def startup_event():
             unsigned_graph,
             signed_node_graph,
         )
-        from indra_network_search.tests import mesh_annotations_dict
+        from indra_network_search.tests import mesh_annotations_dict as mesh_annotations_dict_load
 
         dir_graph = unsigned_graph
         sign_node_graph = signed_node_graph
@@ -363,7 +368,7 @@ def startup_event():
             sign_edge_graph=False,
             use_cache=USE_GRAPH_CACHE,
         )
-        mesh_annotations_dict = load_mesh_annotation_lookup()
+        mesh_annotations_dict_load = load_mesh_annotation_lookup()
 
         try:
             assert all(data["weight"] >= MIN_WEIGHT for _, _, data in dir_graph.edges(data=True))
@@ -386,11 +391,10 @@ def startup_event():
     logger.info("Loading Trie structure with unsigned graph nodes")
     nodes_trie = NodesTrie.from_node_names(graph=dir_graph)
     nsid_trie = NodesTrie.from_node_ns_id(graph=dir_graph)
-    mesh_annotations_trie = NodesTrie.from_curie_name_dict(mesh_annotations_dict)
+    mesh_annotations_trie = NodesTrie.from_curie_name_dict(mesh_annotations_dict_load)
     # This will destroy a handful of mappings that don't have names in the
     # bio ontology, so we pop the '(unnamed)' entry
-    reverse_mesh_map = {v: k for k, v in mesh_annotations_dict.items()}
-    assert reverse_mesh_map.pop("(unnamed)")  # Check that it was actually popped
+    mesh_annotations_dict = mesh_annotations_dict_load
 
     # Set numbers for server status
     STATUS.unsigned_nodes = len(dir_graph.nodes)

--- a/indra_network_search/rest_api.py
+++ b/indra_network_search/rest_api.py
@@ -4,7 +4,7 @@ The IndraNetworkSearch REST API
 import logging
 from datetime import date
 from os import environ
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from depmap_analysis.network_functions.net_functions import MIN_WEIGHT, bio_ontology
 from depmap_analysis.util.io_functions import file_opener
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from tqdm import tqdm
 
-from indra_network_search.autocomplete import NodesTrie, Prefixes
+from indra_network_search.autocomplete import NodesTrie, Prefixes, MeshPrefixes
 from indra_network_search.data_models import (
     MultiInteractorsRestQuery,
     MultiInteractorsResults,
@@ -31,6 +31,7 @@ from indra_network_search.rest_util import (
     dump_query_json_to_s3,
     dump_result_json_to_s3,
     load_indra_graph,
+    load_mesh_annotation_lookup
 )
 from indra_network_search.search_api import IndraNetworkSearchAPI
 
@@ -63,6 +64,8 @@ STATUS = ServerStatus(status="booting", graph_date="2025-08-05")
 network_search_api: IndraNetworkSearchAPI
 nsid_trie: NodesTrie
 nodes_trie: NodesTrie
+mesh_annotations_trie: NodesTrie
+reverse_mesh_map: dict[str, str]  # Maps name -> mesh curie
 
 
 @app.get("/xrefs", response_model=List[List[str]])
@@ -132,6 +135,24 @@ def node_id_in_graph(
         return node
 
 
+@app.get("/mesh-annotation-exists", response_model=Optional[Tuple[str, str]])
+def mesh_annotation_name_exists(
+    mesh_name: str = RestQuery(..., min_length=1, alias="mesh-name"),
+):
+    mesh_id = mesh_annotations_trie.get(mesh_name)
+    if mesh_id:
+        return mesh_name, mesh_id
+
+
+@app.get("/mesh-id-annotation-exists", response_model=Optional[Tuple[str, str]])
+def mesh_id_annotation_exists(
+    mesh_id: str = RestQuery(..., min_length=1, alias="mesh-id"),
+):
+    mesh_name = reverse_mesh_map.get(f"MESH:{mesh_id}")
+    if mesh_name:
+        return mesh_name, mesh_id
+
+
 @app.get("/autocomplete", response_model=Prefixes)
 def get_prefix_autocomplete(
     prefix: str = RestQuery(..., min_length=1),
@@ -186,6 +207,31 @@ def get_prefix_autocomplete(
         nodes = nodes_trie.case_items(prefix=prefix, top_n=max_res)
     logger.info(f"Prefix query resolved with {len(nodes)} suggestions")
     return nodes
+
+
+@app.get("/autocomplete-mesh-name", response_model=MeshPrefixes)
+def get_prefix_autocomplete_mesh(
+    prefix: str = RestQuery(..., min_length=1),
+    max_res: int = RestQuery(100, alias="max-results"),
+) -> MeshPrefixes:
+    """Get the case-insensitive mesh annotation names starting with prefix
+
+    Parameters
+    ----------
+    prefix :
+        The prefix of an annotation name to search for.
+    max_res :
+        The number of results will be returned.
+
+    Returns
+    -------
+    :
+        A list of tuples of (node name, identifier)
+    """
+    annotations = mesh_annotations_trie.case_items_alpha(
+        prefix=prefix, top_n=max_res
+    )
+    return [(name, identifier) for name, _, identifier in annotations]
 
 
 @app.get("/health", response_model=Health)
@@ -293,7 +339,7 @@ def sub_graph(search_query: SubgraphRestQuery):
 
 @app.on_event("startup")
 def startup_event():
-    global network_search_api, nsid_trie, nodes_trie
+    global network_search_api, nsid_trie, nodes_trie, mesh_annotations_trie, reverse_mesh_map
     # Todo: figure out how to do all the loading async so the server is
     #  available to respond to health checks while it's loading
     #  See:
@@ -304,6 +350,7 @@ def startup_event():
             unsigned_graph,
             signed_node_graph,
         )
+        from indra_network_search.tests import mesh_annotations_dict
 
         dir_graph = unsigned_graph
         sign_node_graph = signed_node_graph
@@ -316,6 +363,7 @@ def startup_event():
             sign_edge_graph=False,
             use_cache=USE_GRAPH_CACHE,
         )
+        mesh_annotations_dict = load_mesh_annotation_lookup()
 
         try:
             assert all(data["weight"] >= MIN_WEIGHT for _, _, data in dir_graph.edges(data=True))
@@ -338,6 +386,11 @@ def startup_event():
     logger.info("Loading Trie structure with unsigned graph nodes")
     nodes_trie = NodesTrie.from_node_names(graph=dir_graph)
     nsid_trie = NodesTrie.from_node_ns_id(graph=dir_graph)
+    mesh_annotations_trie = NodesTrie.from_curie_name_dict(mesh_annotations_dict)
+    # This will destroy a handful of mappings that don't have names in the
+    # bio ontology, so we pop the '(unnamed)' entry
+    reverse_mesh_map = {v: k for k, v in mesh_annotations_dict.items()}
+    assert reverse_mesh_map.pop("(unnamed)")  # Check that it was actually popped
 
     # Set numbers for server status
     STATUS.unsigned_nodes = len(dir_graph.nodes)

--- a/indra_network_search/rest_util.py
+++ b/indra_network_search/rest_util.py
@@ -22,6 +22,7 @@ from indra_db.util.s3_path import S3Path
 
 __all__ = [
     "load_indra_graph",
+    "load_mesh_annotation_lookup",
     "check_existence_and_date_s3",
     "dump_result_json_to_s3",
     "dump_query_json_to_s3",
@@ -45,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 API_PATH = path.dirname(path.abspath(__file__))
 CACHE = path.join(API_PATH, "_cache")
+MESH_ANNOTATION_LOOKUP = path.join(CACHE, "mesh_annotation_lookup.pkl")
 
 # Derived type hints
 StrNode = Union[str, Tuple[str, int]]
@@ -133,6 +135,19 @@ def get_latest_graphs() -> Dict[str, str]:
     if len(latest_graphs) == 0:
         logger.warning(f"Found no graphs at s3://{NET_BUCKET}" f"/{NETS_PREFIX}/*.pkl")
     return latest_graphs
+
+
+def load_mesh_annotation_lookup() -> dict[str, str]:
+    """Load the mesh annotation lookup
+
+    Returns
+    -------
+    :
+        Returns a dict mapping mesh id curies to their name as they are set in
+        `indra.ontology.bio.bio_ontology`
+    """
+    mesh_lookup = file_opener(MESH_ANNOTATION_LOOKUP)
+    return mesh_lookup
 
 
 def load_indra_graph(

--- a/indra_network_search/tests/__init__.py
+++ b/indra_network_search/tests/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "hash_bl_edge1",
     "hash_bl_edge2",
     "_get_node",
+    "mesh_annotations_dict",
 ]
 
 wm = _weight_from_belief
@@ -43,6 +44,40 @@ nodes = {
     "NCOA": {"ns": "FPLX", "id": "NCOA"},
     "BRCA": {"ns": "FPLX", "id": "BRCA"},
 }
+
+
+mesh_annotations_dict = dict(
+    [
+        ("MESH:D000072230", "Sustained Virologic Response"),
+        ("MESH:D000067455", "No-Show Patients"),
+        ("MESH:D053669", "Syndecan-2"),
+        ("MESH:C535303", "Charcot-Marie-Tooth disease, X-linked recessive, 3"),
+        ("MESH:D006317", "Hearing Loss, Noise-Induced"),
+        ("MESH:C000648103", "Acetatifactor muris"),
+        ("MESH:D015370", "Infant Equipment"),
+        ("MESH:D031225", "Rorippa"),
+        ("MESH:D047348", "Hydrolyzable Tannins"),
+        ("MESH:D004027", "Diencephalon"),
+        ("MESH:D063127", "Secondary Care"),
+        ("MESH:C535273", "Presenile dementia, Kraepelin type"),
+        ("MESH:C000653063", "Burkholderia pyrrocinia"),
+        ("MESH:C537262", "Hereditary pancreatitis"),
+        ("MESH:D000092130", "Urticaria, Solar"),
+        ("MESH:D031661", "Fraxinus"),
+        ("MESH:D006099", "Granuloma"),
+        ("MESH:D015981", "Epidemiologic Factors"),
+        ("MESH:D025601", "Adenomatous Polyposis Coli Protein"),
+        ("MESH:D000089944", "Core Stability"),
+        ("MESH:C531609", "Diffuse alopecia"),
+        ("MESH:D005934", "Glucagon"),
+        ("MESH:D014872", "Water Movements"),
+        ("MESH:D050316", "Medical Order Entry Systems"),
+        ("MESH:C537171", "Paraquat lung"),
+        ("MESH:C123456", "(unnamed)"),  # To test IDs without names
+        ("MESH:C654321", "(unnamed)"),
+
+    ]
+)
 
 
 def _get_node(name: str) -> Node:

--- a/indra_network_search/tests/test_basemodels.py
+++ b/indra_network_search/tests/test_basemodels.py
@@ -1,4 +1,5 @@
-from indra_network_search.data_models import StmtData
+from pydantic import ValidationError
+from indra_network_search.data_models import StmtData, NetworkSearchQuery
 
 
 def test_stmt_data():
@@ -15,3 +16,40 @@ def test_stmt_data():
     }
     stmt_data = StmtData(db_url_hash=stmt_dict["stmt_hash"], **stmt_dict)
     assert stmt_data.source_counts == {"fplx": 1}
+
+
+def test_network_search_query_mesh():
+    # Test the mesh option validation
+    nsq = NetworkSearchQuery(source="A", weighted="context", mesh_ids=["D000001", "D000002"])
+    try:
+        NetworkSearchQuery(source="A", weighted="context")
+    except Exception as e:
+        assert "mesh_ids must contain at least one MeSH ID" in str(e)
+        assert isinstance(e, ValidationError)
+
+
+def test_network_search_query_cull_best_node():
+    nsq = NetworkSearchQuery(source="A", cull_best_node=2)
+    try:
+        NetworkSearchQuery(source="A", cull_best_node=1)
+    except Exception as e:
+        assert "cull_best_node must be integer > 1" in str(e)
+        assert isinstance(e, ValidationError)
+
+
+def test_network_search_query_max_per_node():
+    nsq = NetworkSearchQuery(source="A", max_per_node=2)
+    try:
+        NetworkSearchQuery(source="A", max_per_node=0)
+    except Exception as e:
+        assert "max_per_node must be integer > 0" in str(e)
+        assert isinstance(e, ValidationError)
+
+
+def test_network_search_query_path_length():
+    nsq = NetworkSearchQuery(source="A", path_length=2)
+    try:
+        NetworkSearchQuery(source="A", path_length=0)
+    except Exception as e:
+        assert "path_length must be integer > 0" in str(e)
+        assert isinstance(e, ValidationError)

--- a/indra_network_search/tests/test_query_pipeline.py
+++ b/indra_network_search/tests/test_query_pipeline.py
@@ -417,6 +417,20 @@ def test_ssp_signed_belief_weighted():
     # Todo: test result
 
 
+def test_ssp_signed_node_blacklist():
+    from indra_network_search.search_api import IndraNetworkSearchAPI
+    nsq = NetworkSearchQuery(
+        filter_curated=False,
+        source="BRCA1",
+        target="BRCA2",
+        node_blacklist=["testosterone"],
+        sign=0,
+    )
+    network_search_api = IndraNetworkSearchAPI(unsigned_graph=unsigned_graph, signed_node_graph=signed_node_graph)
+    results = network_search_api.handle_query(rest_query=nsq)
+    # Todo: test result
+
+
 def test_ssp_z_score_weighted():
     # Create rest query - belief weighted
     brca1 = Node(name="BRCA1", namespace="HGNC", identifier="1100")

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     indra_db @ git+https://github.com/indralab/indra_db.git
     fastapi<0.100.0
     pydantic!=1.8,!=1.8.1,<2.0.0,>=1.7.4
-;    Version 0.28.0 breaks the starlette verion used in fastapi<0.100.0
+;    Version 0.28.0 breaks the starlette version used in fastapi<0.100.0
     httpx==0.27.2
     networkx
     boto3


### PR DESCRIPTION
This PR (rebased on top of #40) implements autocomplete for the MeSH ID input box for mesh context search as well as autocomplete for the node blacklist.

Specific updates:
- Update NodesTrie class to handle MeSH use case
- Add MeSH specific endpoints for checking validity and getting autocomplete suggestions
- Make MeSH term input field multiselect
- Add tests for MeSH annotations
- Add new Vue components for MeSH and node blacklist autocomplete

Separately, the footer for the page is updated to make the text about the app and the lab up to date.